### PR TITLE
Added dir='rtl' for texts with @xml:lang='heb'

### DIFF
--- a/cts_leipzig_ui/data/assets/static/xslt/edition.xsl
+++ b/cts_leipzig_ui/data/assets/static/xslt/edition.xsl
@@ -84,6 +84,11 @@
                 <xsl:value-of select="@xml:lang"/>
             </xsl:attribute>
             <xsl:attribute name="data-lang"><xsl:value-of select="./@xml:lang"/></xsl:attribute>
+            <xsl:if test="@xml:lang = 'heb'">
+                <xsl:attribute name="dir">
+                    <xsl:text>rtl</xsl:text>
+                </xsl:attribute>
+            </xsl:if>
             <xsl:apply-templates/>
         </div>
     </xsl:template>


### PR DESCRIPTION
This fixes the problem of final punctuation showing up on the right side of a line instead of the left.